### PR TITLE
Allow 60 minues, 24 hours ....

### DIFF
--- a/src/Heartsentwined/CronExprParser/Parser.php
+++ b/src/Heartsentwined/CronExprParser/Parser.php
@@ -194,11 +194,8 @@ class Parser
         );
 
         if (is_numeric($value)) {
-            if (in_array((int) $value, $data, true)) {
-                return $value;
-            } else {
-                return false;
-            }
+            // allow all numerics values, this change fix the bug for minutes range like 0-59 or hour range like 0-20
+            return $value;
         }
 
         if (is_string($value)) {


### PR DESCRIPTION
This change allow to use this cron expression : 0-5,10-59/5 \* 2-10,15-25 january-june/2 mon-fri
Without this bug fix, with have an error like 10-59 bad expession ... 59 not in array but it's a good value for minutes.
